### PR TITLE
Fix omz base image tag

### DIFF
--- a/modelserver/Dockerfile
+++ b/modelserver/Dockerfile
@@ -1,5 +1,5 @@
 # Use the OpenVINO Toolkit development image that contains all required scripts and deps
-FROM openvino/ubuntu20_dev AS omz
+FROM openvino/ubuntu20_dev:2021.4.2 AS omz
 
 # Change dir for the colorization model demo
 WORKDIR /opt/intel/openvino_2021.4.752/deployment_tools/open_model_zoo/demos/colorization_demo/python


### PR DESCRIPTION
Hello @valentincanonical 

Thank you very much for creating a very nice example and tutorial. 

I'd like to fix the base image tag for the model server container image as `openvino/ubuntu20_dev:2021.4.2`.  
The build failed with the image `openvino/ubuntu20_dev`.  (Because it is pulling `latest` tag from docker hub.)
```
$ docker build modelserver -t localhost:32000/modelserver:latest
Sending build context to Docker daemon   5.12kB
Step 1/10 : FROM openvino/ubuntu20_dev AS omz
latest: Pulling from openvino/ubuntu20_dev
4d32b49e2995: Pull complete
78e849544284: Pull complete
411e67941194: Pull complete
17aa49426650: Pull complete
72ab56fa1a5a: Pull complete
d8adffee6d1a: Pull complete
b007c88a84bf: Pull complete
5984552a91bf: Pull complete
abe14cd62399: Pull complete
f4cfc712c94f: Pull complete
0c11c7f719aa: Pull complete
5010b5e477bd: Pull complete
b09aac8251a8: Pull complete
b84b10ce4442: Pull complete
6e30a9ddc8c9: Pull complete
634b755f48de: Pull complete
f45e21edd0a2: Pull complete
43162a191a42: Pull complete
3ee2595956b3: Pull complete
723d0062b71d: Pull complete
Digest: sha256:3b16f830655f89639e5a99b172a2db5cbb67e1f9f6f1154423852e9985eb5f05
Status: Downloaded newer image for openvino/ubuntu20_dev:latest
 ---> bf3842f9d5b9
Step 2/10 : WORKDIR /opt/intel/openvino_2021.4.752/deployment_tools/open_model_zoo/demos/colorization_demo/python
 ---> Running in 4678d7f02ef1
Removing intermediate container 4678d7f02ef1
 ---> d748b5bcf506
Step 3/10 : ENV TOOLS /opt/intel/openvino_2021.4.752/deployment_tools/open_model_zoo/tools/downloader
 ---> Running in 92da5e813bf9
Removing intermediate container 92da5e813bf9
 ---> d766fc1c673f
Step 4/10 : RUN mkdir /home/openvino/models
 ---> Running in 505ab6255453
+ mkdir /home/openvino/models
Removing intermediate container 505ab6255453
 ---> 86b9b84ab359
Step 5/10 : RUN $TOOLS/downloader.py --list models.lst -o /home/openvino/models
 ---> Running in 3af25edcf607
+ /opt/intel/openvino_2021.4.752/deployment_tools/open_model_zoo/tools/downloader/downloader.py --list models.lst -o /home/openvino/models
/bin/bash: /opt/intel/openvino_2021.4.752/deployment_tools/open_model_zoo/tools/downloader/downloader.py: No such file or directory
The command '/bin/bash -xo pipefail -c $TOOLS/downloader.py --list models.lst -o /home/openvino/models' returned a non-zero code: 127
``` 

Tested the build and application with `openvino/ubuntu20_dev:2021.4.2` and works fine.  
